### PR TITLE
import semicircle_donut

### DIFF
--- a/metadata/default.meta
+++ b/metadata/default.meta
@@ -1,6 +1,7 @@
 []
 access = read : [ * ], write : [ admin, power ]
 export = system
+import = semicircle_donut
 
 [essentials_updates]
 export = system


### PR DESCRIPTION
without importing the visualization, the RBA dashboard panels show "No matching visualization found for type: semicircle_donut, in app: semicircle_donut"