### PR TITLE
Increased truncate limit

### DIFF
--- a/default/data/ui/views/RBASystemEvents.xml
+++ b/default/data/ui/views/RBASystemEvents.xml
@@ -170,8 +170,8 @@
 | table _time risk_object risk_object_type threat_object threat_object_type 
 | rex field=threat_object mode=sed "s/\"//g"
 | eval orig_threat_object=threat_object
-| eval threat_object=if(len(threat_object)&gt;20,substr(threat_object,1,20)."...",threat_object)
-| search threat_object=* | eval from=risk_object, to=threat_object, type=risk_object_type | appendpipe [| eval from=threat_object, to="", type=threat_object_type] | lookup attack_web_viz type as type | eval linktext=threat_object_type | rename viz as type  | eval value=if(from=threat_object, orig_threat_object, risk_object)</query>
+| eval threat_object=if(len(threat_object)&gt;25,substr(threat_object,1,25)."...",threat_object)
+| search threat_object=* | eval from=risk_object, to=threat_object, type=risk_object_type | appendpipe [| eval from=threat_object, to="", type=threat_object_type] | lookup attack_web_viz type as type | eval linktext=threat_object_type | rename viz as type  | eval value=if(from=threat_object, orig_threat_object, risk_object) | eval to=if(from=to, "", to)</query>
           <earliest>$timepicker.earliest$</earliest>
           <latest>$timepicker.latest$</latest>
         </search>

--- a/default/data/ui/views/RBAUserEvents.xml
+++ b/default/data/ui/views/RBAUserEvents.xml
@@ -173,8 +173,8 @@
 | table _time risk_object risk_object_type threat_object threat_object_type 
 | rex field=threat_object mode=sed "s/\"//g"
 | eval orig_threat_object=threat_object
-| eval threat_object=if(len(threat_object)&gt;20,substr(threat_object,1,20)."...",threat_object)
-| search threat_object=* | eval from=risk_object, to=threat_object, type=risk_object_type | appendpipe [| eval from=threat_object, to="", type=threat_object_type] | lookup attack_web_viz type as type | eval linktext=threat_object_type | rename viz as type  | eval value=if(from=threat_object, orig_threat_object, risk_object)</query>
+| eval threat_object=if(len(threat_object)&gt;25,substr(threat_object,1,25)."...",threat_object)
+| search threat_object=* | eval from=risk_object, to=threat_object, type=risk_object_type | appendpipe [| eval from=threat_object, to="", type=threat_object_type] | lookup attack_web_viz type as type | eval linktext=threat_object_type | rename viz as type  | eval value=if(from=threat_object, orig_threat_object, risk_object) | eval to=if(from=to, "", to)</query>
           <earliest>$timepicker.earliest$</earliest>
           <latest>$timepicker.latest$</latest>
         </search>


### PR DESCRIPTION
Increased truncate limit from 20 to 25 and added line "| eval to=if(from=to, "", to)" which will prevent weird formatting loops in the viz.